### PR TITLE
Commented-out ApplyRowLevelStyle() call in GlimpseTab::GetData()

### DIFF
--- a/src/Serilog.Sinks.Glimpse/Sinks/Glimpse/GlimpseTab.cs
+++ b/src/Serilog.Sinks.Glimpse/Sinks/Glimpse/GlimpseTab.cs
@@ -69,7 +69,7 @@ namespace Serilog.Sinks.Glimpse
                 row.Column(item.LogEvent.RenderMessage(item.FormatProvider)).Strong();
                 row.Column(properties);
 
-                ApplyRowLevelStyle(item.LogEvent.Level, row);
+                //ApplyRowLevelStyle(item.LogEvent.Level, row);
             }
 
             return plugin;


### PR DESCRIPTION
Thank you for developing Serilog.Sinks.Glimpse.

While using it in our project, we noticed that the properties added to our logging statements were only displayed correctly in Glimpse if they were Verbose statements; otherwise, the List namespace would be shown instead.

Investigating into this revealed the cause to be in the ApplyRowLevelStyle() function. This ultimately causes Glimpse to cast the property list to string, which returns the namespace instead of the properties. (See line 32 in https://github.com/Glimpse/Glimpse/blob/c61c88c8a4ba41b78b8030e1c49238a2f6400dcd/source/Glimpse.Core/Tab/Assist/TabSectionRow.cs)

Verbose statements were not affected because the switch statement in ApplyRowLevelStyle() does not check for Verbose level.

See the following screenshot for the difference between Verbose output & Debug output (each statement had the same properties passed in):
![glimpse_serilog](https://cloud.githubusercontent.com/assets/12150344/7614362/39b0e8b4-f98e-11e4-986c-842274b26ddf.png)

This pull request has the call to ApplyRowLevelStyle() commented-out, causing the properties in Debug logging to render correctly in our project.

This might not be the best way to resolve the issue; the pull request is intended to bring this to your attention. If there is a better way, please could you investigate?
