### PR TITLE
Fix formatting issue with LogEventLevel.Debug events

### DIFF
--- a/src/Serilog.Sinks.Glimpse/Sinks/Glimpse/GlimpseTab.cs
+++ b/src/Serilog.Sinks.Glimpse/Sinks/Glimpse/GlimpseTab.cs
@@ -80,7 +80,7 @@ namespace Serilog.Sinks.Glimpse
             switch (level)
             {
                 case LogEventLevel.Debug:
-                    row.Sub();
+                    row.Quiet();
                     break;
                 case LogEventLevel.Warning:
                     row.Warn();


### PR DESCRIPTION
I'm not sure how this could be unit tested, so hopefully that won't be a problem! 

I've tested it manually - the call to `Quiet()` formats the message text in a grey colour rather than black. The other option is to call `Ms()`, which formats the colour and also adds a Visual Studio-type icon in the left-hand column. I chose `Quiet()` because I found the VS icon a bit intrusive, and the original `Sub()` was presumably intended to reduce the visual impact of Debug messages rather than increase it.

The [Contributing](https://github.com/serilog/serilog/wiki/Contributing) page asks to set up the PR to target the dev branch, but there doesn't appear to be one in this repo. If I've got it wrong, happy to fix it - not fluent in Git yet :)
