### PR TITLE
Row level styles for all Serilog levels

### DIFF
--- a/src/Serilog.Sinks.Glimpse/Sinks/Glimpse/GlimpseTab.cs
+++ b/src/Serilog.Sinks.Glimpse/Sinks/Glimpse/GlimpseTab.cs
@@ -79,8 +79,14 @@ namespace Serilog.Sinks.Glimpse
         {
             switch (level)
             {
-                case LogEventLevel.Debug:
+                case LogEventLevel.Verbose:
                     row.Quiet();
+                    break;
+                /*case LogEventLevel.Debug:
+                    // Default style, black text
+                    break;*/
+                case LogEventLevel.Information:
+                    row.Info();
                     break;
                 case LogEventLevel.Warning:
                     row.Warn();


### PR DESCRIPTION
Thank you both Nicholas Blumhardt & Rich Tebb for resolving the problem - it appears row.Sub() (& row.Raw()) in Glimpse.Core have trouble handling properties correctly, but the other styles work fine.

To this end, I propose the following changes, so that all six Serilog levels are accounted for:
- Verbose level to use row.Quiet() (instead of Debug level, as Verbose is the lowest)
- Debug level to use standard formatting (i.e. no style function applied)
- Information level to use row.Info()
- Warning/Error/Fatal to use what they're already set-up with.

Refer to the following screenshot for what this looks like:
![glimpse_serilog_all_level_styles](https://cloud.githubusercontent.com/assets/12150344/7982594/6aa19382-0ab0-11e5-9059-5eaaa3a9343e.png)

What do you think?
