### PR TITLE
Fix minor typo in README link formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/692ndogowuda2dn7/branch/master?svg=true)](https://ci.appveyor.com/project/serilog/serilog-sinks-glimpse/branch/master)
 
 
-A sink for Serilog that writes events to [Glimpse](http://getglimpse.com].
+A sink for Serilog that writes events to [Glimpse](http://getglimpse.com).
 
 **Package** - [Serilog.Sinks.Glimpse](http://nuget.org/packages/serilog.sinks.glimpse)
 | **Platforms** - .NET 4.5


### PR DESCRIPTION
The Glimpse link was a little mangled due to `]` vs `)`. Happened upon it and thought I'd make the edit.
